### PR TITLE
fix/docker-and-redis

### DIFF
--- a/pioniere-backend/Dockerfile
+++ b/pioniere-backend/Dockerfile
@@ -1,11 +1,13 @@
 FROM node:lts-alpine
 
-RUN mkdir -p /pioniere-backend/node_modules && chown -R node:node /pioniere-backend
-WORKDIR /pioniere-backend
+WORKDIR /usr/src/pioniere-backend
+
 COPY package*.json ./
-COPY .env ./
-USER node
 RUN npm install
+
+COPY .env ./
+COPY . .
 COPY --chown=node:node . .
 EXPOSE 3000
+
 CMD ["npm", "run", "dev"]

--- a/pioniere-backend/app.js
+++ b/pioniere-backend/app.js
@@ -8,7 +8,6 @@ var dotenv = require('dotenv');
 dotenv.config();
 
 var indexRouter = require('./routes/index');
-
 var app = express();
 
 app.use(logger('dev'));

--- a/pioniere-backend/package.json
+++ b/pioniere-backend/package.json
@@ -15,7 +15,7 @@
     "googleapis": "60.0.1",
     "http-errors": "~1.6.3",
     "jade": "~1.11.0",
-    "morgan": "~1.9.1",,
+    "morgan": "~1.9.1",
     "redis": "^3.0.2"
   },
   "devDependencies": {

--- a/pioniere-backend/redis-client/redis-client.js
+++ b/pioniere-backend/redis-client/redis-client.js
@@ -2,29 +2,38 @@ var redis = require('redis');
 
 class RedisClient {
     constructor() {
-        this.client= this.getClient()
+        this.client = this.getClientInstance();
+
         this.client.on('error', function (err) {
             console.log('Error ' + err);
-        }); 
-        
-        this.client.on('connect', function() {
+        });
+
+        this.client.on('connect', function () {
             console.log('Connected to Redis');
         });
     }
-    getClient(){
-        if(this.client)
-            return this.client
-        this.client = redis.createClient({host:'redis', port: 6379})
-        return this.client 
+
+    getClientInstance() {
+        if (this.client) return this.client
+        const redisClient = redis.createClient({
+            host: 'redis',
+            port: process.env.REDIS_PORT || 6379
+        })
+        return redisClient
     }
 
-    setObject(key, value){
+    setObject(key, value) {
         this.client.set(key, JSON.stringify(value))
     }
 
-    getObject(key){
-        let value = this.client.get(key)
-        return JSON.parse(value)
+    getObject(key, deserialize = true) {
+        return new Promise((resolve, reject) => {
+            this.client.get(key, (error, value) => {
+                if (error) reject(error)
+                if (deserialize) value = JSON.parse(value)
+                resolve(value)
+            })
+        })
     }
 }
 


### PR DESCRIPTION
updated routes and logs to retrieve data from Redis. also, as 'node-redis' does not support promises, the 'client.get' call has been wrapped inside a promise